### PR TITLE
Hide CaptainsMessListener variables in inspector

### DIFF
--- a/Assets/CaptainsMess/CaptainsMessListener.cs
+++ b/Assets/CaptainsMess/CaptainsMessListener.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 
 public class CaptainsMessListener : MonoBehaviour
 {
+	[HideInInspector]
 	public CaptainsMess mess;
 
 	public void Awake()

--- a/Assets/CaptainsMess/Example/ExampleListener.cs
+++ b/Assets/CaptainsMess/Example/ExampleListener.cs
@@ -14,6 +14,7 @@ public class ExampleListener : CaptainsMessListener
 		Connected,
 		Disrupted
 	};
+	[HideInInspector]
 	public NetworkState networkState = NetworkState.Init;
 	public Text networkStateField;
 	public ExampleGameSession gameSession;


### PR DESCRIPTION
In CaptainsMessListener, we don't need the "mess" variable exposed in the editor as it will define itself at runtime.

Likewise, in the ExampleListener, we don't need to be able to set the Network State in the editor as it is being displayed through the Network State Field text object.
