### PR TITLE
Bug fix: maxConnections not changed

### DIFF
--- a/Assets/CaptainsMess/CaptainsMess.cs
+++ b/Assets/CaptainsMess/CaptainsMess.cs
@@ -36,7 +36,7 @@ public class CaptainsMess : MonoBehaviour
             networkManager.runInBackground = false; // runInBackground is not recommended on iOS
             networkManager.broadcastIdentifier = broadcastIdentifier;
             networkManager.minPlayers = minPlayers;
-            networkManager.maxPlayers = maxPlayers;
+            networkManager.SetMaxPlayers(maxPlayers); //Setting maxPlayers and maxConnections
             networkManager.allReadyCountdownDuration = countdownDuration;
 
             // I'm just using a single scene for everything

--- a/Assets/CaptainsMess/CaptainsMessLobbyManager.cs
+++ b/Assets/CaptainsMess/CaptainsMessLobbyManager.cs
@@ -11,8 +11,14 @@ public class CaptainsMessLobbyManager : NetworkManager
     public int maxPlayers = 4;
     public CaptainsMessPlayer[] lobbySlots;
     public int maxPlayersPerConnection = 1;
+    
+    public void SetMaxPlayers(int value)
+    {
+        maxPlayers = value;
+        maxConnections = maxPlayers;
+    }
 
-	// ==================== SERVER ====================
+    // ==================== SERVER ====================
 
     public override void OnStartServer()
     {


### PR DESCRIPTION
## Problem

maxConnections stays at the default value, 4, no matter what maxPlayers is set to.
## Solution

Added SetMaxPlayers function that sets both maxPlayers variable as well as maxConnections.

In CaptainsMess, now calling that function rather than set directly. This enables games with more than 4 players.

Tested this fix in my game, seems to work.
## Alternate Solutions?

Is maxPlayers redundant, should it be replaced by maxConnections?

Argument for keeping two variables:
- Name convention matching with minPlayers
- Could change maxConnections to add/remove more players and/or spectators without effecting the maximum number of players

Arguments for removing
- Have to make sure maxConnections >= maxPlayers whenever maxPlayers changes

I believe it makes sense to keep them separate, as I like the idea of adding a spectator mode to my game at some point.
